### PR TITLE
Puppetdb catalog

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -49,6 +49,14 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary "Whether to filter nodes on the old server's environment in PuppetDB"
     end
 
+    option "--old_catalog_from_puppetdb" do
+      summary "Get old catalog from PuppetDB inside of compile master"
+    end
+
+    option "--new_catalog_from_puppetdb" do
+      summary "Get new catalog from PuppetDB inside of compile master"
+    end
+
     option "--changed_depth=" do
       summary "The number of nodes to display sorted by changes"
       default_to { "10" }
@@ -151,7 +159,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         # User passed use two hostnames
         old_catalogs = Dir.mktmpdir("#{catalog1.gsub('/', '_')}-")
         new_catalogs = Dir.mktmpdir("#{catalog2.gsub('/', '_')}-")
-        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_old_env => options[:filter_old_env], :filter_local => options[:filter_local], :certless => options[:certless])
+        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_old_env => options[:filter_old_env], :filter_local => options[:filter_local], :certless => options[:certless], :old_catalog_from_puppetdb => options[:old_catalog_from_puppetdb], :new_catalog_from_puppetdb => options[:new_catalog_from_puppetdb])
         diff_output = Puppet::Face[:catalog, '0.0.1'].diff(old_catalogs,new_catalogs,options)
         nodes = diff_output
         FileUtils.rm_rf(old_catalogs)

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -32,6 +32,14 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary "Whether to filter nodes on the old server's environment in PuppetDB"
     end
 
+    option "--old_catalog_from_puppetdb" do
+      summary "Get old catalog from PuppetDB inside of compile master"
+    end
+
+    option "--new_catalog_from_puppetdb" do
+      summary "Get new catalog from PuppetDB inside of compile master"
+    end
+
     option "--filter_local" do
       summary "Use local YAML node files to filter out queried nodes"
     end
@@ -79,11 +87,11 @@ Puppet::Face.define(:catalog, '0.0.1') do
          while node_name = mutex.synchronize { nodes.pop }
             begin
               if nodes.size.odd?
-                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless] )
-                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless] )
+                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless],:catalog_from_puppetdb => options[:old_catalog_from_puppetdb])
+                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless],:catalog_from_puppetdb => options[:new_catalog_from_puppetdb])
               else
-                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless] )
-                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless] )
+                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless],:catalog_from_puppetdb => options[:new_catalog_from_puppetdb])
+                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless],:catalog_from_puppetdb => options[:old_catalog_from_puppetdb])
               end
               mutex.synchronize { compiled_nodes + old_server[:compiled_nodes] }
               mutex.synchronize { compiled_nodes + new_server[:compiled_nodes] }

--- a/lib/puppet/face/catalog/seed.rb
+++ b/lib/puppet/face/catalog/seed.rb
@@ -16,6 +16,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary "Use the certless catalog API (Puppet >= 6.3.0)"
     end
 
+    option "--catalog_from_puppetdb" do
+      summary "Get catalog from PuppetDB instead of compile master"
+    end
+
     description <<-'EOT'
       This action is used to seed a series of catalogs to then be compared with diff
     EOT
@@ -57,7 +61,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         Thread.new(nodes,compiled_nodes,options) do |nodes,compiled_nodes,options|
           while node_name = mutex.synchronize { nodes.pop }
             begin
-              compiled = Puppet::CatalogDiff::CompileCatalog.new(node_name,save_directory,options[:master_server],options[:certless])
+              compiled = Puppet::CatalogDiff::CompileCatalog.new(node_name,save_directory,options[:master_server],options[:certless],options[:catalog_from_puppetdb])
               mutex.synchronize { compiled_nodes << node_name }
             rescue Exception => e
               Puppet.err("Unable to compile catalog for #{node_name}\n\t#{e}")


### PR DESCRIPTION
This PR adds two new options: `--old_catalog_from_puppetdb` and `--new_catalog_from_puppetdb` to allow to get cached catalogs from PuppetDB instead of compiling them.

This makes retrieval much faster, and allows to run a diff between Puppet 5 and Puppet 6 with trusted facts.