### PR TITLE
Ignore parameters

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -37,6 +37,12 @@ module Puppet::CatalogDiff
         #resource[:parameters].delete(:command) unless new_resource[:parameters].include?(:command)
         #resource[:parameters].delete(:path) unless new_resource[:parameters].include?(:path)
 
+        if options[:ignore_parameters]
+          blacklist = options[:ignore_parameters].split(',')
+          filter_parameters!(new_resource[:parameters], blacklist)
+          filter_parameters!(resource[:parameters], blacklist)
+        end
+
         sort_dependencies!(new_resource[:parameters])
         sort_dependencies!(resource[:parameters])
 
@@ -80,6 +86,11 @@ module Puppet::CatalogDiff
       resource_differences[:old_params]  = parameters_in_old
       resource_differences[:new_params]  = parameters_in_new
       resource_differences
+    end
+
+    # filter parameters
+    def filter_parameters!(params, blacklist)
+      params.reject! { |p, k| blacklist.include?(p.to_s) }
     end
 
     # sort require/before/notify/subscribe before comparison

--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -75,7 +75,6 @@ module Puppet::CatalogDiff
         end
       end
 
-
       Puppet.debug("Processing: #{from_file}")
       titles = {}
       titles[:to] = extract_titles(to)

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -37,6 +37,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary 'Do not print classes in resource diffs'
     end
 
+    option '--ignore_parameters=' do
+      summary 'A comma-separated list of resource parameters to ignore in diff'
+    end
+
     option "--filter_local" do
       summary "Use local YAML node files to filter out queried nodes"
     end


### PR DESCRIPTION
This PR adds a `--ignore_parameters=` option to ignore resource parameters in diff.

This is useful for ex when diffing between Puppet 5 and 6, where the `alias` parameter is removed for many resources.