### PR TITLE
Fix problem where a node's details wouldn't load/show in puppet-catalog-diff-viewer

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -84,8 +84,8 @@ module Puppet::CatalogDiff
       titles[:from] = extract_titles(from)
 
       output = {}
-      output[:old_version] = from_meta[:version]
-      output[:new_version] = to_meta[:version]
+      output[:old_version] = from_meta[:version].to_s
+      output[:new_version] = to_meta[:version].to_s
 
       output[:old_environment] = from_meta[:environment]
       output[:new_environment] = to_meta[:environment]


### PR DESCRIPTION
Fix problem where a node's details wouldn't load/show in puppet-catalog-diff-viewer when the JSON-file is generated on a Puppet Master that has server configuration config_version set to generate Epoch numbers. In this case these numbers where stored as numbers instead of strings in the JSON-file which caused puppet-catalog-diff-viewer to throw an exception when it tries to replace strange characters in the version string. I've verified this works in latest version of puppet-catalog-diff-viewer. See also conversation on #puppet here https://puppetcommunity.slack.com/archives/C0W298S9G/p1594642754396700.