### PR TITLE
Get rid of obsolete URI.escape

### DIFF
--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -53,7 +53,7 @@ module Puppet::CatalogDiff
       _server, environment = server.split('/')
       environment ||= lookup_environment(node_name)
       query.concat([['=', 'environment', environment]])
-      json_query = URI.escape(query.to_json)
+      json_query = URI.encode_www_form_component(query.to_json)
       ret = connection.request_get("/pdb/query/v4/catalogs?query=#{json_query}", 'Accept' => 'application/json').body
       begin
         catalog = PSON.parse(ret)

--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -43,7 +43,7 @@ module Puppet::CatalogDiff
                ['=', 'title', capit]]]]]],
         )
       end
-      json_query = URI.escape(query.to_json)
+      json_query = URI.encode_www_form_component(query.to_json)
       begin
         filtered = PSON.parse(connection.request_get("/pdb/query/v4/nodes?query=#{json_query}", 'Accept' => 'application/json').body)
       rescue PSON::ParserError => e


### PR DESCRIPTION
This fixes catalog-diff with Puppet 6.16+ (Puppet 6.15 is broken anyway)