### PR TITLE
Include list of `all_changed_nodes` in json report

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -204,6 +204,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:most_differences]   = most_differences.reverse.take((options.key?(:changed_depth) && options[:changed_depth].to_i || 10))
       nodes[:total_nodes]        = total_nodes
       nodes[:date]               = Time.new.iso8601
+      nodes[:all_changed_nodes]  = with_changes.keys
       nodes
     end
 
@@ -212,7 +213,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
 
       format = Puppet::CatalogDiff::Formater.new
       nodes.map { |node, summary|
-        next if [:total_percentage, :total_nodes, :most_changed, :with_changes, :most_differences, :pull_output, :date].include?(node)
+        next if [:total_percentage, :total_nodes, :most_changed, :with_changes, :most_differences, :pull_output, :date, :all_changed_nodes].include?(node)
 
         format.node_summary_header(node, summary, :node_percentage) + summary.map { |header, value|
           next if value.nil?


### PR DESCRIPTION
Currently, `puppet-catalog-diff-viewer` only looks at the nodes in
`most_differences` to decide which nodes to display as 'with changes'
and 'no changes'.  By default, this list is limited to just 10 nodes
with the most differences.  Including a complete list of changed nodes
in the json (regardless of `--changed_depth`) will make fixing
puppet-catalog-diff-viewer much easier.