### PR TITLE
Use `prefer_requested_environment` `true`

### DIFF
--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -84,6 +84,9 @@ module Puppet::CatalogDiff
             facts: false,
             catalog: false,
           },
+          options: {
+            prefer_requested_environment: true,
+          },
         }
       else
         endpoint = "/puppet/v3/catalog/#{node_name}?environment=#{environment}"


### PR DESCRIPTION
"Whether to always override a node’s classified environment with the
one supplied in the request. If this is true and no environment is
supplied, fall back to the classified environment, or finally,
‘production’"

https://puppet.com/docs/puppetserver/latest/puppet-api/v4/catalog.html#options