### PR TITLE
Adds backward compatibility with older version of PuppetDB used in Puppet 3, to support Puppet 3 to 5 upgrades

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -53,7 +53,7 @@ module Puppet::CatalogDiff
 
         if options[:show_resource_diff]
           Puppet.debug("Resource diff: #{resource[:resource_id]}")
-
+          puts 'show_resource_diff'
           diff_array = str_diff(
             Puppet::CatalogDiff::Formater.new.resource_to_string(resource),
             Puppet::CatalogDiff::Formater.new.resource_to_string(new_resource),
@@ -136,6 +136,22 @@ module Puppet::CatalogDiff
       else
         str2 = cont2
         sum2 = Digest::MD5.hexdigest(str2)
+      end
+
+      puts "str_diff: str1: #{str1} str1.encoding: #{str1.encoding}"
+      puts "str_diff: str2: #{str2} str2.encoding: #{str2.encoding}"
+      unless str1.valid_encoding?
+        Puppet::debug("content parameter in old resource has invalid #{str1.encoding} encoding.")
+        str1.encode!('UTF-8', 'UTF-8', :invalid => :replace)
+        puts "str_diff: str1 fixed str1: #{str1} str1.encoding: #{str1.encoding}"
+        unless str1.valid_encoding?
+          puts "str1 STILL WRONG!"
+        end
+      end
+      unless str2.valid_encoding?
+        Puppet::debug("content parameter in new resource has invalid #{str2.encoding} encoding.")
+        str2.encode!('UTF-8', 'UTF-8', :invalid => :replace)
+        puts "str2 fixed str2: #{str2} str2.encoding: #{str2.encoding}"
       end
 
       return nil unless str1 && str2

--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -53,7 +53,7 @@ module Puppet::CatalogDiff
 
         if options[:show_resource_diff]
           Puppet.debug("Resource diff: #{resource[:resource_id]}")
-          puts 'show_resource_diff'
+
           diff_array = str_diff(
             Puppet::CatalogDiff::Formater.new.resource_to_string(resource),
             Puppet::CatalogDiff::Formater.new.resource_to_string(new_resource),
@@ -138,20 +138,13 @@ module Puppet::CatalogDiff
         sum2 = Digest::MD5.hexdigest(str2)
       end
 
-      puts "str_diff: str1: #{str1} str1.encoding: #{str1.encoding}"
-      puts "str_diff: str2: #{str2} str2.encoding: #{str2.encoding}"
       unless str1.valid_encoding?
         Puppet::debug("content parameter in old resource has invalid #{str1.encoding} encoding.")
         str1.encode!('UTF-8', 'UTF-8', :invalid => :replace)
-        puts "str_diff: str1 fixed str1: #{str1} str1.encoding: #{str1.encoding}"
-        unless str1.valid_encoding?
-          puts "str1 STILL WRONG!"
-        end
       end
       unless str2.valid_encoding?
         Puppet::debug("content parameter in new resource has invalid #{str2.encoding} encoding.")
         str2.encode!('UTF-8', 'UTF-8', :invalid => :replace)
-        puts "str2 fixed str2: #{str2} str2.encoding: #{str2.encoding}"
       end
 
       return nil unless str1 && str2

--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -119,6 +119,14 @@ module Puppet::CatalogDiff
       diff
     end
 
+    def validate_encoding(str)
+      unless str.valid_encoding?
+        Puppet::debug("Detected that string used in diff had invalid #{str.encoding} encoding. Replacing invalid characters in diff output.")
+        str.encode!('UTF-8', 'UTF-8', :invalid => :replace)
+      end
+      str
+    end 
+    
     def str_diff(cont1, cont2)
       return nil unless cont1 && cont2
 
@@ -137,6 +145,9 @@ module Puppet::CatalogDiff
         str2 = cont2
         sum2 = Digest::MD5.hexdigest(str2)
       end
+
+      str1 = validate_encoding(str1)
+      str2 = validate_encoding(str2)
 
       return nil unless str1 && str2
       return nil if sum1 == sum2

--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -138,15 +138,6 @@ module Puppet::CatalogDiff
         sum2 = Digest::MD5.hexdigest(str2)
       end
 
-      unless str1.valid_encoding?
-        Puppet::debug("content parameter in old resource has invalid #{str1.encoding} encoding.")
-        str1.encode!('UTF-8', 'UTF-8', :invalid => :replace)
-      end
-      unless str2.valid_encoding?
-        Puppet::debug("content parameter in new resource has invalid #{str2.encoding} encoding.")
-        str2.encode!('UTF-8', 'UTF-8', :invalid => :replace)
-      end
-
       return nil unless str1 && str2
       return nil if sum1 == sum2
 

--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -23,7 +23,7 @@ module Puppet::CatalogDiff
 
     def build_query(env, version)
       base_query = ['and', ['=', ['node', 'active'], true]]
-      query_field_catalog_environment = Puppet::Util::Package.versioncmp(version, '3') > 0 ? 'catalog_environment' : 'catalog-environment'
+      query_field_catalog_environment = Puppet::Util::Package.versioncmp(version, '3') >= 0 ? 'catalog_environment' : 'catalog-environment'
       base_query.concat([['=', query_field_catalog_environment, env]]) if env
       real_facts = @facts.reject { |_k, v| v.nil? }
       query = base_query.concat(real_facts.map { |k, v| ['=', ['fact', k], v] })

--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -21,14 +21,14 @@ module Puppet::CatalogDiff
       active_nodes
     end
 
-    def find_nodes_puppetdb(env)
-      require 'puppet/util/puppetdb'
-      server_url = Puppet::Util::Puppetdb.config.server_urls[0]
-      port = server_url.port
-      use_ssl = port != 8080
-      connection = Puppet::Network::HttpPool.http_instance(server_url.host, port, use_ssl)
+    def build_query(env, version)
       base_query = ['and', ['=', ['node', 'active'], true]]
-      base_query.concat([['=', 'catalog_environment', env]]) if env
+      if version == 'latest'
+        query_field_catalog_environment = 'catalog_environment'
+      else
+        query_field_catalog_environment = 'catalog-environment'
+      end
+      base_query.concat([['=', query_field_catalog_environment, env]]) if env
       real_facts = @facts.reject { |_k, v| v.nil? }
       query = base_query.concat(real_facts.map { |k, v| ['=', ['fact', k], v] })
       classes = Hash[@facts.select { |_k, v| v.nil? }].keys
@@ -43,9 +43,28 @@ module Puppet::CatalogDiff
                ['=', 'title', capit]]]]]],
         )
       end
-      json_query = URI.encode_www_form_component(query.to_json)
+      query
+    end
+
+    def find_nodes_puppetdb(env)
+      require 'puppet/util/puppetdb'
+      puppetdb_version = 'latest'
+      server_url = Puppet::Util::Puppetdb.config.server_urls[0]
+      port = server_url.port
+      use_ssl = port != 8080
+      connection = Puppet::Network::HttpPool.http_instance(server_url.host, port, use_ssl)
+      query = build_query(env, puppetdb_version)
+      json_query = URI.escape(query.to_json)
       begin
-        filtered = PSON.parse(connection.request_get("/pdb/query/v4/nodes?query=#{json_query}", 'Accept' => 'application/json').body)
+        result = connection.request_get("/pdb/query/v4/nodes?query=#{json_query}", 'Accept' => 'application/json')
+        if result.code.to_i >= 400
+          puppetdb_version = '2.3'
+          Puppet::debug("Query returned HTTP code #{result.code}. Falling back to older version of API used in PuppetDB version #{puppetdb_version}.")
+          query = build_query(env, puppetdb_version)
+          json_query = URI.escape(query.to_json)
+          result = connection.request_get("/v4/nodes/?query=#{json_query}", 'Accept' => 'application/json')
+        end
+        filtered = PSON.parse(result.body)
       rescue PSON::ParserError => e
         raise "Error parsing json output of puppet search: #{e.message}"
       end

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -19,7 +19,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { Facter.value('fqdn') }
     end
 
-    option '--threads' do
+    option '--threads=' do
       summary 'The number of threads to use'
       default_to { '10' }
     end

--- a/spec/unit/puppet/catalog_diff/comparer_spec.rb
+++ b/spec/unit/puppet/catalog_diff/comparer_spec.rb
@@ -86,18 +86,12 @@ describe Puppet::CatalogDiff::Comparer do
       Encoding.default_internal = 'UTF-8'
       Encoding.default_external = 'UTF-8' # Needed because diff uses tempfile.
       
-      puts "Encoding.default_internal: #{Encoding.default_internal}"
       latin1_string = [246].pack('C*').force_encoding('UTF-8')
       res1[0][:parameters][:content] = latin1_string 
-      puts "latin1_string.encoding: #{latin1_string.encoding}"
-      #puts "latin1_string: #{latin1_string}"
-      #puts "latin1_string.bytes: #{latin1_string.bytes}"
       expect{compare_resources(res1, res2, show_resource_diff: true)}.not_to raise_error(ArgumentError)
       diffs = compare_resources(res1, res2, show_resource_diff: true)
-      #puts "diffs: #{diffs}"
-      puts "diffs: #{diffs[:string_diffs]['file.foo'][3].bytes}"
+      
       ruby_default_replacement_string_for_invalid_characters = '�'
-       
       expect(diffs[:string_diffs]['file.foo'][3]).to \
         eq("-\t     content => \"" + ruby_default_replacement_string_for_invalid_characters + "\"")
     end

--- a/spec/unit/puppet/catalog_diff/comparer_spec.rb
+++ b/spec/unit/puppet/catalog_diff/comparer_spec.rb
@@ -79,22 +79,6 @@ describe Puppet::CatalogDiff::Comparer do
       diffs = compare_resources(res1, res2, show_resource_diff: true)
       expect(diffs[:string_diffs]['file.foo'][3]).to eq("-\t     content => \"foo content\"")
     end
-      
-    it 'returns string_diffs with show_resource_diff with content encoded in ISO8859-1 (latin1)' do
-      # Without this the unit test fails when running on LC_ALL=C but works with LC_ALL=en_US.UTF-8
-      # With this it works on both.
-      Encoding.default_internal = 'UTF-8'
-      Encoding.default_external = 'UTF-8' # Needed because diff uses tempfile.
-      
-      latin1_string = [246].pack('C*').force_encoding('UTF-8')
-      res1[0][:parameters][:content] = latin1_string 
-      expect{compare_resources(res1, res2, show_resource_diff: true)}.not_to raise_error
-      diffs = compare_resources(res1, res2, show_resource_diff: true)
-      
-      ruby_default_replacement_string_for_invalid_characters = '�'
-      expect(diffs[:string_diffs]['file.foo'][3]).to \
-        eq("-\t     content => \"" + ruby_default_replacement_string_for_invalid_characters + "\"")
-    end
 
     it 'returns a diff without path parameter' do
       diffs = compare_resources(res1, res2, ignore_parameters: 'path')

--- a/spec/unit/puppet/catalog_diff/comparer_spec.rb
+++ b/spec/unit/puppet/catalog_diff/comparer_spec.rb
@@ -79,6 +79,22 @@ describe Puppet::CatalogDiff::Comparer do
       diffs = compare_resources(res1, res2, show_resource_diff: true)
       expect(diffs[:string_diffs]['file.foo'][3]).to eq("-\t     content => \"foo content\"")
     end
+      
+    it 'returns string_diffs with show_resource_diff with content encoded in ISO8859-1 (latin1)' do
+      # Without this the unit test fails when running on LC_ALL=C but works with LC_ALL=en_US.UTF-8
+      # With this it works on both.
+      Encoding.default_internal = 'UTF-8'
+      Encoding.default_external = 'UTF-8' # Needed because diff uses tempfile.
+      
+      latin1_string = [246].pack('C*').force_encoding('UTF-8')
+      res1[0][:parameters][:content] = latin1_string 
+      expect{compare_resources(res1, res2, show_resource_diff: true)}.not_to raise_error
+      diffs = compare_resources(res1, res2, show_resource_diff: true)
+      
+      ruby_default_replacement_string_for_invalid_characters = '�'
+      expect(diffs[:string_diffs]['file.foo'][3]).to \
+        eq("-\t     content => \"" + ruby_default_replacement_string_for_invalid_characters + "\"")
+    end
 
     it 'returns a diff without path parameter' do
       diffs = compare_resources(res1, res2, ignore_parameters: 'path')

--- a/spec/unit/puppet/catalog_diff/comparer_spec.rb
+++ b/spec/unit/puppet/catalog_diff/comparer_spec.rb
@@ -88,7 +88,7 @@ describe Puppet::CatalogDiff::Comparer do
       
       latin1_string = [246].pack('C*').force_encoding('UTF-8')
       res1[0][:parameters][:content] = latin1_string 
-      expect{compare_resources(res1, res2, show_resource_diff: true)}.not_to raise_error(ArgumentError)
+      expect{compare_resources(res1, res2, show_resource_diff: true)}.not_to raise_error
       diffs = compare_resources(res1, res2, show_resource_diff: true)
       
       ruby_default_replacement_string_for_invalid_characters = '�'


### PR DESCRIPTION
Adds backward compatibility to retrieve catalogs from older PuppetDB version 2.3 used in Puppet 3 in the latest version of puppet-catalog-diff. This is necessary when you want to use puppet-catalog-diff to compare the catalogues between a Puppet 3 and Puppet 5 Master, as we did when we upgraded to Puppet 5. This code adds a fallback to the older /v4/nodes/?query PuppetDB API if the latest version of the API, that is /pdb/query/v4/nodes?, fails. This means that the code is compatible with both versions and thus allows the latest version of puppet-catalog-diff to still be used together with Puppet 3 servers, which is useful for those who still hasn't upgraded to newer version of Puppet.

We needed to use this change in combination with https://github.com/camptocamp/puppet-catalog-diff/pull/38 in our environment, but this change does not require this pull request as long as the encoding is valid UTF-8 in the catalogues stored in PuppetDB on the Puppet 3 Master server.