### PR TITLE
Prevent 'false' from showing up in the console report

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -241,7 +241,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
             format.key_pair(header, value)
           end
         }.delete_if { |x| x.nil? || x == [] }.join("\n")
-      }.join("\n") + "#{format.node_summary_header("#{nodes[:with_changes]} out of #{nodes[:total_nodes]} nodes changed.", nodes, :total_percentage)}\n#{format.list_hash('Nodes with the most changes by percent changed', nodes[:most_changed])}\n\n#{format.list_hash('Nodes with the most changes by differences', nodes[:most_differences], '')}#{(nodes.key?(:pull_output) && format.render_pull(nodes[:pull_output]))}"
+      }.join("\n") + "#{format.node_summary_header("#{nodes[:with_changes]} out of #{nodes[:total_nodes]} nodes changed.", nodes, :total_percentage)}\n#{format.list_hash('Nodes with the most changes by percent changed', nodes[:most_changed])}\n\n#{format.list_hash('Nodes with the most changes by differences', nodes[:most_differences], '')}#{format.render_pull(nodes[:pull_output]) if nodes.key?(:pull_output)}"
     end
   end
 end


### PR DESCRIPTION
Prior to this, when viewing the report in the console after diffing two
catalog files, the word "false" would show up right next to the number
of "Nodes with the most changes by differences".

For example, note the errant "false" at the end of this:
```
--------------------------------------------------------------------------------
1 out of 1 nodes changed.                                   0.34%
--------------------------------------------------------------------------------

Nodes with the most changes by percent changed:
1. foo.bar.net-production                                     0.34%

Nodes with the most changes by differences:
1. foo.bar.net-some_feature                                   8false
```

This was due to a Ruby `.key?` check inside a string interpolation of
`nodes[:puppet_ouput]`, which when ":pull_output" was not a key in the
`nodes` hash evaluated to `false`. And since `false` was inside the
string interpolation, it got printed to the console.

This fixes that by switching to the "x if condition y" format of
conditional logic, which hides the output of the `.key?` check.

After this commit, the console output does not contain the word "false".
```
--------------------------------------------------------------------------------
1 out of 1 nodes changed.                                   0.34%
--------------------------------------------------------------------------------

Nodes with the most changes by percent changed:
1. foo.bar.net-production                                     0.34%

Nodes with the most changes by differences:
1. foo.bar.net-some_feature                                   8
```
