### PR TITLE
Make --output_report work when diffing two catalog files or directories.

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -178,16 +178,16 @@ Puppet::Face.define(:catalog, '0.0.1') do
         FileUtils.rm_rf(old_catalogs)
         FileUtils.rm_rf(new_catalogs)
         nodes[:pull_output] = pull_output
-        # Save the file as it can take a while to create
-        if options[:output_report]
-          Puppet.notice("Writing report to disk: #{options[:output_report]}")
-          File.open(options[:output_report], 'w') do |f|
-            f.write(nodes.to_json)
-          end
-        end
         return nodes
       end
       raise 'No nodes were matched' if nodes.size.zero?
+
+      if options[:output_report]
+        Puppet.notice("Writing report to disk: #{options[:output_report]}")
+        File.open(options[:output_report], 'w') do |f|
+          f.write(nodes.to_json)
+        end
+      end
 
       with_changes = nodes.select { |_node, summary| summary.is_a?(Hash) && !summary[:node_percentage].zero? }
       most_changed = with_changes.sort_by { |_node, summary| summary[:node_percentage] }.map do |node, summary|


### PR DESCRIPTION
Prior to this, the `--output_report` flag only worked when invoking
`puppet catalog diff` with two hostnames (i.e. when remotely compiling
catalogs). If you tried to diff two catalog files and save a report, the
report would not be saved.

After this, the `--outuput_report` flag works will all invocations of
`puppet catalog diff` and a report will be saved if used when passing
two catalog files.

For example, this now correctly saves a report:
```
puppet catalog diff catalog-A.json catalog-B.json --output_report ~/report.json
```

Fixes issue #37
