### PR TITLE
Don't crash `puppet catalog seed` when trying to output failed nodes

### DIFF
--- a/lib/puppet/face/catalog/seed.rb
+++ b/lib/puppet/face/catalog/seed.rb
@@ -88,7 +88,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         key.each do |node|
           "Compiled Node: #{node}"
         end
-      }.join("\n") + "#{output[:failed_nodes].join("\n")}\nFailed on #{output[:failed_nodes].size} nodes"
+      }.join("\n") + "#{output[:failed_nodes].to_a.join("\n")}\nFailed on #{output[:failed_nodes].size} nodes"
     end
   end
 end


### PR DESCRIPTION
`Hash` does not have a join method. Convert `output[:failed_nodes]` to an array before joining.

Fixes #51