### PR TITLE
Include stats in json created from 2 catalog dirs

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -182,13 +182,6 @@ Puppet::Face.define(:catalog, '0.0.1') do
       end
       raise 'No nodes were matched' if nodes.size.zero?
 
-      if options[:output_report]
-        Puppet.notice("Writing report to disk: #{options[:output_report]}")
-        File.open(options[:output_report], 'w') do |f|
-          f.write(nodes.to_json)
-        end
-      end
-
       with_changes = nodes.select { |_node, summary| summary.is_a?(Hash) && !summary[:node_percentage].zero? }
       most_changed = with_changes.sort_by { |_node, summary| summary[:node_percentage] }.map do |node, summary|
         Hash[node => summary[:node_percentage]]
@@ -205,6 +198,14 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:total_nodes]        = total_nodes
       nodes[:date]               = Time.new.iso8601
       nodes[:all_changed_nodes]  = with_changes.keys
+
+      if options[:output_report]
+        Puppet.notice("Writing report to disk: #{options[:output_report]}")
+        File.open(options[:output_report], 'w') do |f|
+          f.write(nodes.to_json)
+        end
+      end
+
       nodes
     end
 


### PR DESCRIPTION
If you want to view in [Puppet Catalog Diff Viewer](https://github.com/camptocamp/puppet-catalog-diff-viewer) diffs generated from
the form of `puppet catalog diff` that takes two directories of old/new
pre-compiled catalogs:

    puppet catalog diff /tmp/old /tmp/new --output_report diff.json

You need to have the stats available in the json report, otherwise when
it's loaded into the browser you will encounter js errors for undefined
attributes, for example [here](https://github.com/camptocamp/puppet-catalog-diff-viewer/blob/4946e3f3ddc1e24c72b6e3d273c6e0d555e5d729/catalog_viewer.js#L161).