### PR TITLE
Include node stats in output report

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -187,13 +187,6 @@ Puppet::Face.define(:catalog, '0.0.1') do
       end
       raise 'No nodes were matched' if nodes.size.zero?
 
-      if options[:output_report]
-        Puppet.notice("Writing report to disk: #{options[:output_report]}")
-        File.open(options[:output_report], 'w') do |f|
-          f.write(nodes.to_json)
-        end
-      end
-
       with_changes = nodes.select { |_node, summary| summary.is_a?(Hash) && !summary[:node_percentage].zero? }
       most_changed = with_changes.sort_by { |_node, summary| summary[:node_percentage] }.map do |node, summary|
         Hash[node => summary[:node_percentage]]
@@ -211,6 +204,13 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:date]               = Time.new.iso8601
       nodes[:all_changed_nodes]  = with_changes.keys
       nodes
+
+      if options[:output_report]
+        Puppet.notice("Writing report to disk: #{options[:output_report]}")
+        File.open(options[:output_report], 'w') do |f|
+          f.write(nodes.to_json)
+        end
+      end
     end
 
     when_rendering :console do |nodes|

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -203,7 +203,6 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:total_nodes]        = total_nodes
       nodes[:date]               = Time.new.iso8601
       nodes[:all_changed_nodes]  = with_changes.keys
-      nodes
 
       if options[:output_report]
         Puppet.notice("Writing report to disk: #{options[:output_report]}")
@@ -211,6 +210,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
           f.write(nodes.to_json)
         end
       end
+      nodes
     end
 
     when_rendering :console do |nodes|


### PR DESCRIPTION
A regression was introduced in 16730d65acb795805310dfb340b4fea1403ecbee where report outputs did not include node change overviews.  This is required for the diff viewer tool to properly generate a report.  This pull request moves the output_report if statement to further down so that it will include the necessary stats.

Fixes https://github.com/camptocamp/puppet-catalog-diff/issues/57